### PR TITLE
Fix installation in next@10 using npm@7

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   "peerDependencies": {
     "@aws-amplify/auth": "^3.2.3",
     "@aws-amplify/core": "^3.2.3",
-    "next": "^9.3.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "next": ">=9.3.0",
+    "react": ">=16.13.1",
+    "react-dom": ">=16.13.1"
   },
   "devDependencies": {
     "@aws-amplify/auth": "^3.2.3",
@@ -60,5 +60,9 @@
     "prop-types": "15.7.2",
     "query-string": "^6.12.1",
     "yargs": "^15.3.1"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dferber90/aws-cognito-next"
+  },
 }


### PR DESCRIPTION
I getting this error using `npm@7` and I fixed your package, because your npm works properly with `next@10.0.6` :grimacing: 

```
npm ERR! Found: next@10.0.6
npm ERR! node_modules/next
npm ERR!   next@"10.0.6" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer next@"^9.3.0" from aws-cognito-next@3.0.0
npm ERR! node_modules/aws-cognito-next
npm ERR!   aws-cognito-next@"^3.0.0" from the root project
```

Also I added the repository URL to have the link to this repository in the npm page of this package.