### PR TITLE
simple replacement for encoded plus sign

### DIFF
--- a/src/cognito.ts
+++ b/src/cognito.ts
@@ -6,6 +6,12 @@ const unauthenticatedCookies = {
   accessToken: null,
 };
 
+// if userId has a plus sign e.g. me+mine@gmail.com then the cookie key 
+// preserves the plus sign
+function userIdToTokenKey(userId){
+  return encodeURIComponent(userId).replace(/%2B/g, '+');
+}
+
 // returns all auth cookies
 export function getCognitoCookieInfo(
   cookieString: string | undefined,
@@ -30,12 +36,12 @@ export function getCognitoCookieInfo(
   const lastUser = cookieData[lastUserKey] ? cookieData[lastUserKey] : null;
 
   const idTokenKey = lastUser
-    ? `${prefix}.${encodeURIComponent(lastUser)}.idToken`
+    ? `${prefix}.${userIdToTokenKey(lastUser)}.idToken`
     : null;
   const idToken =
     idTokenKey && cookieData[idTokenKey] ? cookieData[idTokenKey] : null;
   const accessTokenKey = lastUser
-    ? `${prefix}.${encodeURIComponent(lastUser)}.accessToken`
+    ? `${prefix}.${userIdToTokenKey(lastUser)}.accessToken`
     : null;
   const accessToken =
     accessTokenKey && cookieData[accessTokenKey]

--- a/src/cognito.ts
+++ b/src/cognito.ts
@@ -6,10 +6,11 @@ const unauthenticatedCookies = {
   accessToken: null,
 };
 
-// if userId has a plus sign e.g. me+mine@gmail.com then the cookie key 
-// preserves the plus sign
-function userIdToTokenKey(userId:string) :string{
-  return encodeURIComponent(userId).replace(/%2B/g, '+');
+// use same algorithm as js-cookie as used in aws-amplify/auth@4.20
+function userIdToTokenKey(key:string) :string{
+   return encodeURIComponent(key)
+      .replace(/%(2[346B]|5E|60|7C)/g, decodeURIComponent)
+      .replace(/[()]/g, escape);
 }
 
 // returns all auth cookies

--- a/src/cognito.ts
+++ b/src/cognito.ts
@@ -8,7 +8,7 @@ const unauthenticatedCookies = {
 
 // if userId has a plus sign e.g. me+mine@gmail.com then the cookie key 
 // preserves the plus sign
-function userIdToTokenKey(userId){
+function userIdToTokenKey(userId:string) :string{
   return encodeURIComponent(userId).replace(/%2B/g, '+');
 }
 


### PR DESCRIPTION
When working with a User Pool that has an email address as the user key instead of a UUID I found that an aliased user appeared to be logged in but in the next app they never showed as logged in. 

This fixes the issue. 