### PR TITLE
add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# aws-cognito-next
+# aws-cognito-next (Deprecated)
 
 Authentication helpers to enable usage of [AWS Cognito](https://aws.amazon.com/en/cognito/) in [next.js](https://nextjs.org/) applications.
 
 > **Update (2020–09–29)**: aws-amplify has added support for server-side rendering since this package was created. You can read [the announcement](https://aws.amazon.com/de/blogs/mobile/ssr-support-for-aws-amplify-javascript-libraries/) for details. You might be able to use aws-amplify directly instead of the more manual approach shown in this package.
+
+> **Update (2021-11-17)**: **This package is being deprecated** as more viable alternatives became available since I started the package. Alternatives have more lively communities and better outlook for the future. Consider using the [AWS Amplify Next.js integration](https://docs.amplify.aws/start/q/integration/next/) or the [Next Auth with its Cognito Provider](https://next-auth.js.org/providers/cognito). A heartfelt thank you to everyone who gave this early project a chance.
 
 ### Quick links
 
@@ -23,7 +25,7 @@ See [MDN](https://developer.mozilla.org/de/docs/Web/HTTP/Cookies) for more infor
 
 ## Table of contents
 
-- [aws-cognito-next](#aws-cognito-next)
+- [aws-cognito-next (Deprecated)](#aws-cognito-next-deprecated)
     - [Quick links](#quick-links)
     - [Pros](#pros)
     - [Cons](#cons)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # aws-cognito-next (Deprecated)
 
+**This package is no longer maintained.**
+
 Authentication helpers to enable usage of [AWS Cognito](https://aws.amazon.com/en/cognito/) in [next.js](https://nextjs.org/) applications.
 
 > **Update (2020–09–29)**: aws-amplify has added support for server-side rendering since this package was created. You can read [the announcement](https://aws.amazon.com/de/blogs/mobile/ssr-support-for-aws-amplify-javascript-libraries/) for details. You might be able to use aws-amplify directly instead of the more manual approach shown in this package.
 
-> **Update (2021-11-17)**: **This package is being deprecated** as more viable alternatives became available since I started the package. Alternatives have more lively communities and better outlook for the future. Consider using the [AWS Amplify Next.js integration](https://docs.amplify.aws/start/q/integration/next/) or the [Next Auth with its Cognito Provider](https://next-auth.js.org/providers/cognito). A heartfelt thank you to everyone who gave this early project a chance.
+> **Update (2021-11-17)**: **This package is deprecated.** Although I think `aws-cognito-next` has its advantages, especially with the ideas in [#9](https://github.com/dferber90/aws-cognito-next/issues/9), the reality is that I am no longer using `aws-cognito-next` myself so I have no guidance on the importance of features or an actual use for it if I'd finish a feature. More viable alternatives became available since I started this package. Alternatives have more lively communities and better outlook for the future. Consider using the [AWS Amplify Next.js integration](https://docs.amplify.aws/start/q/integration/next/) or [Next Auth with its Cognito Provider](https://next-auth.js.org/providers/cognito). A heartfelt thank you to everyone who gave this early package a chance. Feel free to DM me on Twitter if you are using this package and are up for maintaining it.
 
 ### Quick links
 


### PR DESCRIPTION
I am planning to deprecate this package since the corporate project I originally created it for got scrapped. This puts me in a situation where it's hard to see the vision feature-wise and I am no longer using it myself. 

I therefore plan to stop maintaining and deprecate `aws-cognito-next` as I want to prevent new people from starting new projects based on `aws-cognito-next`.

Viable alternatives exist now that Next Auth is a thing and now that AWS has a Next.js Integration.

@ericclemmons @balazsorban44 But before I go forward with this, I wanted to check in with you as **this package and [its accompanying article](https://frontend-digest.com/authentication-in-next-js-using-amazon-cognito-f30efed6a24f) still are the first search result for "nextjs cognito" and other terms.**.

@ericclemmons Is there any interest from AWS's side? You had mentioned some ideas in https://github.com/dferber90/aws-cognito-next/issues/4#issuecomment-656318674
@balazsorban44 Is there any interest from Next Auth's side?

Otherwise my plan is to npm deprecate the package, archive the repo and link to AWS and Next Auth as viable alternatives. And to mention this in the article as well.

closes #4